### PR TITLE
Stop trying to send custom UA to neeva.com

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -633,7 +633,6 @@ extension BrowserViewController: WKNavigationDelegate {
             pendingRequests[url.absoluteString] = navigationAction.request
 
             if NeevaConstants.isAppHost(url.host) {
-                webView.customUserAgent = UserAgent.neevaAppUserAgent()
                 setCookiesForNeeva(webView: webView, isPrivate: tab.isPrivate)
             } else if tab.changedUserAgent {
                 let platformSpecificUserAgent = UserAgent.oppositeUserAgent(

--- a/Client/Frontend/Settings/Neeva/NeevaSettingsSection.swift
+++ b/Client/Frontend/Settings/Neeva/NeevaSettingsSection.swift
@@ -18,7 +18,6 @@ struct NeevaSettingsSection: View {
             configuration: config
         )
         webView.allowsLinkPreview = false
-        webView.customUserAgent = UserAgent.neevaAppUserAgent()
         webView.load(URLRequest(url: NeevaConstants.appSettingsURL))
 
         return webView

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -129,10 +129,6 @@ public struct UserAgentBuilder {
         return makeMobileUserAgent(identifier: "Version/\(UIDevice.current.systemVersion)")
     }
 
-    public static func neevaMobileUserAgent() -> UserAgentBuilder {
-        return makeMobileUserAgent(identifier: "NeevaBrowserIOS/\(AppInfo.appVersion)")
-    }
-
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(
             product: UserAgent.product, systemInfo: "(Macintosh; Intel Mac OS X 10.15)",

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -50,11 +50,6 @@ open class UserAgent {
         }
     }
 
-    public static func neevaAppUserAgent() -> String {
-        // TODO: Consider selecting a desktop UA string on iPad
-        return UserAgentBuilder.neevaMobileUserAgent().userAgent()
-    }
-
     public static func getUserAgent(domain: String, platform: UserAgentPlatform) -> String {
         switch platform {
         case .Desktop:


### PR DESCRIPTION
Address #642. Still need to migrate analytics to stop using the custom UA for version checking graph: 

https://app.mode.com/neeva/reports/3dc09701a704/viz/8dac3021fefa/explore