### PR TITLE
use removeValue to update tab group name dictionary

### DIFF
--- a/Client/Frontend/Browser/Card/BrowserPrimitive.swift
+++ b/Client/Frontend/Browser/Card/BrowserPrimitive.swift
@@ -374,12 +374,10 @@ class TabGroupManager: AccessingManager, ClosingManager, ObservableObject {
         }
 
         // Filter out deleted tab group names
-        var temp = [String: String]()
-        tabGroups.filter {
-            group in tabGroups[group.key] != nil
+        tabGroupDict.filter {
+            group in tabGroups[group.key] == nil
         }.forEach { group in
-            temp[group.key] = tabGroupDict[group.key]
+            tabGroupDict.removeValue(forKey: group.key)
         }
-        tabGroupDict = temp
     }
 }

--- a/Client/Frontend/Browser/Card/BrowserPrimitive.swift
+++ b/Client/Frontend/Browser/Card/BrowserPrimitive.swift
@@ -7,6 +7,7 @@ import SDWebImageSwiftUI
 import Shared
 import Storage
 import SwiftUI
+import Network
 
 /// The intention for a browser primitive is to represent any metadata or entity tied to a url with a card in a heterogenous UI. Tabs are
 /// the canonical browser primitive, but Spaces, a single entry in a Space, a History entry, a product in a web page can be a browser
@@ -374,10 +375,9 @@ class TabGroupManager: AccessingManager, ClosingManager, ObservableObject {
         }
 
         // Filter out deleted tab group names
-        tabGroupDict.filter {
-            group in tabGroups[group.key] == nil
-        }.forEach { group in
-            tabGroupDict.removeValue(forKey: group.key)
+        tabGroupDict.removeAll()
+        tabGroups.forEach { group in
+            tabGroupDict[group.key] = group.value.displayTitle
         }
     }
 }


### PR DESCRIPTION
## Checklists

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

What I did in this PR:

- instead of building a new dictionary and copy it to tabGroupDict, filter out value using removeValue()

Not sure if this will be helpful, but some of the crashes happens when copying over the dictionary:

<img width="1219" alt="Screen Shot 2021-11-23 at 4 06 09 PM" src="https://user-images.githubusercontent.com/87332917/143148247-c1af80ba-8f19-478b-b2e0-9d140c48f396.png">


 I wonder if it's meaningful to try this way to filter out the value instead. Also, there's a minor flaw with the way I used to filter value:

```
tabGroups.filter {
    group in tabGroups[group.key] != nil
}.forEach{...}
```

Wasn't the filter function doing nothing because it's checking whether itself has that value or not?