### PR TITLE
unpin a tab if it's no longer part of a tab group

### DIFF
--- a/Client/Frontend/Browser/Card/CardDetails.swift
+++ b/Client/Frontend/Browser/Card/CardDetails.swift
@@ -132,9 +132,10 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
 
     public let id: String
     var manager: TabManager
+    var isChild: Bool
 
     var isPinned: Bool {
-        manager.get(for: id)?.isPinned ?? false
+        isChild ? (manager.get(for: id)?.isPinned ?? false) : false
     }
 
     var url: URL? {
@@ -164,9 +165,10 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
 
     // Avoiding keeping a reference to classes both to minimize surface area these Card classes have
     // access to, but also to not worry about reference copying while using CardDetails for View updates.
-    init(tab: Tab, manager: TabManager) {
+    init(tab: Tab, manager: TabManager, isChild: Bool = false) {
         self.id = tab.id
         self.manager = manager
+        self.isChild = isChild
     }
 
     public func performDrop(info: DropInfo) -> Bool {
@@ -505,7 +507,8 @@ class TabGroupCardDetails: CardDetails, AccessingManagerProvider, ClosingManager
             .map({
                 TabCardDetails(
                     tab: $0,
-                    manager: manager.tabManager)
+                    manager: manager.tabManager,
+                    isChild: true)
             }) ?? []
     }
 

--- a/Client/Frontend/Browser/Card/CollapsableCardGroupView.swift
+++ b/Client/Frontend/Browser/Card/CollapsableCardGroupView.swift
@@ -94,6 +94,10 @@ struct CollapsableCardGroupView: View {
             ) {
                 ForEach(groupDetails.allDetails) { childTabDetail in
                     FittedCard(details: childTabDetail, dragToClose: false)
+                        .contextMenu {
+                            FeatureFlag[.tabGroupsPinning]
+                                ? TabGroupContextMenu(details: childTabDetail) : nil
+                        }
                         .matchedGeometryEffect(id: childTabDetail.id, in: cardGroup)
                         .modifier(
                             CardTransitionModifier(
@@ -129,6 +133,10 @@ struct CollapsableCardGroupView: View {
                 HStack(spacing: CardGridUX.GridSpacing) {
                     ForEach(row) { childTabDetail in
                         FittedCard(details: childTabDetail, dragToClose: false)
+                            .contextMenu {
+                                FeatureFlag[.tabGroupsPinning]
+                                    ? TabGroupContextMenu(details: childTabDetail) : nil
+                            }
                             .matchedGeometryEffect(id: childTabDetail.id, in: cardGroup)
                             .modifier(
                                 CardTransitionModifier(

--- a/Client/Frontend/Browser/Card/TabGroupContextMenu.swift
+++ b/Client/Frontend/Browser/Card/TabGroupContextMenu.swift
@@ -7,7 +7,7 @@ import Shared
 import SwiftUI
 
 public struct TabGroupContextMenu: View {
-    @ObservedObject var details: TabCardDetails
+    let details: TabCardDetails
     public var body: some View {
         Button(action: {
             details.manager.get(for: details.id)?.isPinned.toggle()

--- a/Client/Frontend/Browser/Card/TabGroupContextMenu.swift
+++ b/Client/Frontend/Browser/Card/TabGroupContextMenu.swift
@@ -7,12 +7,12 @@ import Shared
 import SwiftUI
 
 public struct TabGroupContextMenu: View {
-    let details: TabCardDetails
+    @ObservedObject var details: TabCardDetails
     public var body: some View {
         Button(action: {
             details.manager.get(for: details.id)?.isPinned.toggle()
         }) {
-            details.manager.get(for: details.id)?.isPinned ?? false
+            (details.manager.get(for: details.id)?.isPinned ?? false)
                 ? Label("Unpin tab", systemSymbol: .pinSlash) : Label("Pin tab", systemSymbol: .pin)
         }
     }

--- a/Client/Frontend/Browser/Tabs/Tab.swift
+++ b/Client/Frontend/Browser/Tabs/Tab.swift
@@ -40,7 +40,7 @@ protocol TabDelegate {
 
 class Tab: NSObject, ObservableObject {
     let isIncognito: Bool
-    @Published var isPinned: Bool = false
+    var isPinned: Bool = false
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
     // rest of the tab.

--- a/Client/Frontend/Browser/Tabs/Tab.swift
+++ b/Client/Frontend/Browser/Tabs/Tab.swift
@@ -40,7 +40,7 @@ protocol TabDelegate {
 
 class Tab: NSObject, ObservableObject {
     let isIncognito: Bool
-    var isPinned: Bool = false
+    @Published var isPinned: Bool = false
 
     // PageMetadata is derived from the page content itself, and as such lags behind the
     // rest of the tab.

--- a/Client/Frontend/Browser/Tabs/TabManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabManager.swift
@@ -462,7 +462,9 @@ class TabManager: NSObject, ObservableObject {
 
             tab.parent = parent
             if FeatureFlag[.tabGroupsPinning] {
-                tab.parent?.isPinned = (tab.parent?.parentUUID == nil)
+                // When restoring tabs, a tab's parentUUID will default to "" if it's nil. The second check
+                // is to ensure a tab is auto-pinned when it forms a tab group after the first run.
+                tab.parent?.isPinned = (tab.parent?.parentUUID == nil || tab.parent?.parentUUID == "")
             }
             tab.parentUUID = parent.tabUUID
             tab.rootUUID = parent.rootUUID


### PR DESCRIPTION
## Checklists

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

Fixes #2553

What I did in this PR:

- add variable `isChild` to TabCardDetails and only show pins if it evaluates to true

https://user-images.githubusercontent.com/87332917/150309399-85a6bb2e-9e9c-4c04-92ba-1a6d1d37819c.mp4


