### PR TITLE
inline tab group BuildRows logic refactoring

### DIFF
--- a/Client/Frontend/Browser/Card/CardModels.swift
+++ b/Client/Frontend/Browser/Card/CardModels.swift
@@ -112,21 +112,28 @@ class TabCardModel: CardModel {
             if partialResult.isEmpty || partialResult.last?.cells.count == maxCols
                 || tabGroup != nil
             {
-                if let tabGroup = tabGroup, tabGroup.isExpanded {
-                    for index in stride(from: 0, to: tabGroup.allDetails.count, by: maxCols) {
-                        var max = index + maxCols
-                        if max > tabGroup.allDetails.count {
-                            max = tabGroup.allDetails.count
+                if let tabGroup = tabGroup {
+                    if tabGroup.isExpanded {
+                        for index in stride(from: 0, to: tabGroup.allDetails.count, by: maxCols) {
+                            var max = index + maxCols
+                            if max > tabGroup.allDetails.count {
+                                max = tabGroup.allDetails.count
+                            }
+                            let range = index..<max
+                            partialResult.append(
+                                Row(cells: [Row.Cell.tabGroupGridRow(tabGroup, range)]))
                         }
-                        let range = index..<max
-                        partialResult.append(
-                            Row(cells: [Row.Cell.tabGroupGridRow(tabGroup, range)]))
+                    } else {
+                        if (tabGroup.allDetails.count + (partialResult.last?.cells.count ?? 0)) <= maxCols {
+                            partialResult[partialResult.endIndex - 1].cells.append(.tabGroupInline(tabGroup))
+                        } else {
+                            partialResult.append(Row(cells: [Row.Cell.tabGroupInline(tabGroup)]))
+                        }
                     }
                 } else {
-                    partialResult.append(
-                        Row(cells: [tabGroup.map(Row.Cell.tabGroupInline) ?? .tab(details)]))
+                    partialResult.append(Row(cells: [.tab(details)]))
                 }
-                if tabGroup != nil {
+                if tabGroup != nil && partialResult.last?.cells.count == maxCols {
                     partialResult.append(Row(cells: []))
                 }
             } else {
@@ -140,7 +147,7 @@ class TabCardModel: CardModel {
         allDetails = manager.getAll()
             .map { TabCardDetails(tab: $0, manager: manager) }
 
-        modifyAllDetailsAvoidingSingleTabs(groupManager.childTabs)
+        //modifyAllDetailsAvoidingSingleTabs(groupManager.childTabs)
 
         allDetailsWithExclusionList = manager.getAll().filter {
             !groupManager.childTabs.contains($0)


### PR DESCRIPTION
Remove the function 'modifyAllDetailsAvoidingSingleTabs' and simply process the tabs/tab groups in order. If the row we're working on can fit the next incoming tab/tab group, then put them in the same row. 

Based on a previous design sync, here are the rules for displaying inline tab groups:
- Tab groups must have at least two tabs
- If the tab group has fewer tabs than the number of remaining columns in the current row, display it in-line
- If the tab group has more tabs than the number of remaining columns in the current row, but fewer tabs than the number of columns in the tab switcher, start a new row containing the tab group
- If the tab group has more tabs than the number of columns in the tab switcher, then make the tabs in the group scroll horizontally and show the expand/collapse button

For more information, please refer to https://www.figma.com/file/t1jW7cahkClVHAIlnHJuv8/Tab-Manager-(Spaces-%26-Tab-Groups)?node-id=2291%3A8659