### PR TITLE
support drag-and-drop in tab switcher

### DIFF
--- a/Client/Frontend/Browser/Card/Card.swift
+++ b/Client/Frontend/Browser/Card/Card.swift
@@ -161,6 +161,7 @@ struct FittedCard<Details>: View where Details: CardDetails {
 struct Card<Details>: View where Details: CardDetails {
     @ObservedObject var details: Details
     var dragToClose = false
+    var dragNDrop = FeatureFlag[.dragAndDropTabs]
     /// Whether — if this card is selected — the blue border should be drawn
     var showsSelection = true
     var animate = false
@@ -250,6 +251,12 @@ struct Card<Details>: View where Details: CardDetails {
         .accesibilityFocus(
             shouldFocus: details.isSelected, trigger: cardTransitionModel.state == .hidden
         )
+        .if(dragNDrop && tabCardDetail != nil && !tabCardDetail!.isChild) { view in
+            view.onDrag({
+                tabCardDetail?.tabCardModel?.draggingDetail = tabCardDetail
+                return NSItemProvider(contentsOf: URL(string: "\(details.id)")!)!
+            })
+        }
         .onDrop(of: ["public.url", "public.text"], delegate: details)
         .if(let: details.closeButtonImage) { buttonImage, view in
             view

--- a/Client/Frontend/Browser/Card/CardDetails.swift
+++ b/Client/Frontend/Browser/Card/CardDetails.swift
@@ -184,21 +184,6 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
     }
 
     public func performDrop(info: DropInfo) -> Bool {
-        guard info.hasItemsConforming(to: ["public.url"]) else {
-            return false
-        }
-
-        let items = info.itemProviders(for: ["public.url"])
-        for item in items {
-            _ = item.loadObject(ofClass: URL.self) { url, _ in
-                if let url = url {
-                    DispatchQueue.main.async {
-                        self.manager.get(for: self.id)?.loadRequest(URLRequest(url: url))
-                    }
-                }
-            }
-        }
-
         return true
     }
 
@@ -207,7 +192,6 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
         guard let tabCardModel = tabCardModel else {
             return
         }
-
         
         let fromIndex = tabCardModel.allDetails.firstIndex {
             $0.id == tabCardModel.draggingDetail?.id
@@ -218,16 +202,8 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
         } ?? 0
 
         if fromIndex != toIndex {
-//            let fromDetail = tabCardModel.allDetails[fromIndex]
-//            tabCardModel.allDetails[fromIndex] = tabCardModel.allDetails[toIndex]
-//            tabCardModel.allDetails[toIndex] = fromDetail
-            
             tabCardModel.allDetails.rearrange(from: fromIndex, to: toIndex)
         }
-        
-        
-        
-        
     }
 
     public func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -244,10 +220,8 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
         } ?? 0
 
         if fromIndex != toIndex {
-//            manager.swapTabs(fromIndex: fromIndex, toIndex: toIndex)
             manager.rearrangeTabs(fromIndex: fromIndex, toIndex: toIndex)
         }
-
         return DropProposal(operation: .move)
     }
 

--- a/Client/Frontend/Browser/Card/CardDetails.swift
+++ b/Client/Frontend/Browser/Card/CardDetails.swift
@@ -208,6 +208,7 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
             return
         }
 
+        
         let fromIndex = tabCardModel.allDetails.firstIndex {
             $0.id == tabCardModel.draggingDetail?.id
         } ?? 0
@@ -217,10 +218,16 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
         } ?? 0
 
         if fromIndex != toIndex {
-            let fromDetail = tabCardModel.allDetails[fromIndex]
-            tabCardModel.allDetails[fromIndex] = tabCardModel.allDetails[toIndex]
-            tabCardModel.allDetails[toIndex] = fromDetail
+//            let fromDetail = tabCardModel.allDetails[fromIndex]
+//            tabCardModel.allDetails[fromIndex] = tabCardModel.allDetails[toIndex]
+//            tabCardModel.allDetails[toIndex] = fromDetail
+            
+            tabCardModel.allDetails.rearrange(from: fromIndex, to: toIndex)
         }
+        
+        
+        
+        
     }
 
     public func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -237,7 +244,8 @@ public class TabCardDetails: CardDetails, AccessingManagerProvider,
         } ?? 0
 
         if fromIndex != toIndex {
-            manager.swapTabs(fromIndex: fromIndex, toIndex: toIndex)
+//            manager.swapTabs(fromIndex: fromIndex, toIndex: toIndex)
+            manager.rearrangeTabs(fromIndex: fromIndex, toIndex: toIndex)
         }
 
         return DropProposal(operation: .move)
@@ -674,5 +682,11 @@ class TabGroupCardDetails: CardDetails, AccessingManagerProvider, ClosingManager
         if let item = manager.get(for: id) {
             manager.close(item, showToast: showToast)
         }
+    }
+}
+
+extension Array {
+    mutating func rearrange(from: Int, to: Int) {
+        insert(remove(at: from), at: to)
     }
 }

--- a/Client/Frontend/Browser/Card/CardModels.swift
+++ b/Client/Frontend/Browser/Card/CardModels.swift
@@ -32,6 +32,7 @@ class TabCardModel: CardModel {
     @Published var allDetails: [TabCardDetails] = []
     @Published private(set) var allDetailsWithExclusionList: [TabCardDetails] = []
     @Published private(set) var selectedTabID: String? = nil
+    @Published var draggingDetail: TabCardDetails?
     @Default(.tabGroupExpanded) private var tabGroupExpanded: Set<String>
 
     var normalDetails: [TabCardDetails] {
@@ -248,7 +249,7 @@ class TabCardModel: CardModel {
     func onDataUpdated() {
         groupManager.updateTabGroups()
         allDetails = manager.getAll()
-            .map { TabCardDetails(tab: $0, manager: manager) }
+            .map { TabCardDetails(tab: $0, manager: manager, tabCardModel: self) }
         
         if FeatureFlag[.reverseChronologicalOrdering] {
             allDetails = allDetails.reversed()

--- a/Client/Frontend/Browser/Tabs/TabManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabManager.swift
@@ -782,6 +782,10 @@ class TabManager: NSObject {
         tabs[fromIndex] = tabs[toIndex]
         tabs[toIndex] = fromTab
     }
+    
+    func rearrangeTabs(fromIndex: Int, toIndex: Int) {
+        tabs.rearrange(from: fromIndex, to: toIndex)
+    }
 
     func getRecentlyClosedTabForURL(_ url: URL) -> SavedTab? {
         assert(Thread.isMainThread)

--- a/Client/Frontend/Browser/Tabs/TabManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabManager.swift
@@ -777,6 +777,12 @@ class TabManager: NSObject {
         // don't we need to generate a .didClose TabEvent?
     }
 
+    func swapTabs(fromIndex: Int, toIndex: Int) {
+        let fromTab = tabs[fromIndex]
+        tabs[fromIndex] = tabs[toIndex]
+        tabs[toIndex] = fromTab
+    }
+
     func getRecentlyClosedTabForURL(_ url: URL) -> SavedTab? {
         assert(Thread.isMainThread)
         return recentlyClosedTabs.joined().filter({ $0.url == url }).first

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -14,6 +14,7 @@ public enum FeatureFlag: String, CaseIterable, RawRepresentable {
     case cardStrip = "Carousel of cards instead of tab strip"
     case topCardStrip = "Top Card Strip"
     case debugURLBar = "URL Bar Debug Mode"
+    case dragAndDropTabs = "Drag and drop tabs in tab switcher"
     case inlineAccountSettings = "Inline Account Settings"
     case newTrackingProtectionSettings = "New Tracking Protection Settings"
     case pinToTopSites = "Pin to Top Sites"


### PR DESCRIPTION
Poking around right now...

https://user-images.githubusercontent.com/87332917/156290759-8296ce76-4496-40fd-abc4-ab11a491f749.MP4

I have a few questions for now:

1. Why is the `performDrop` needed in TabCardDetails? I haven't understood why this part is needed

```
                    DispatchQueue.main.async {
                        self.manager.get(for: self.id)?.loadRequest(URLRequest(url: url))
                    }
```

2. What do the strings in the argument `.onDrop(of: ["public.url", "public.text"], delegate: details)` represent? Does it work with any custom strings we give as long as we are consistent on the sender and receiver?

3. I have to tweak TabCardDetails to let it have access to CardModels so that it can do the swapping on AllDetails when drag and drop event happens. This is making me thinking that it might be actually important (or better) to have TabCardDetails access CardModels instead of TabManager.

4. I also see another problem - Are we allowing drag-and-drop to happen between child tabs and individual tabs? What are we expecting to see when a user drags a child tab outside of a tab group? Are we implicitly making 'remove out of group' happening as an intermediate step? Does the other tab that gets swapped become part of the tab group after?