### PR TITLE
Avoid Force Unwrapping in CardModels.buildRows filter

### DIFF
--- a/Client/Frontend/Browser/Card/CardModels.swift
+++ b/Client/Frontend/Browser/Card/CardModels.swift
@@ -124,7 +124,9 @@ class TabCardModel: CardModel {
 
         var partialResult: [Row] = []
         var allDetailsFiltered = allDetails.filter { tabCard in
-            let tab = tabCard.manager.get(for: tabCard.id)!
+            guard let tab = tabCard.manager.get(for: tabCard.id) else {
+                return false
+            }
             return
                 (tabGroupModel.representativeTabs.contains(tab)
                 || allDetailsWithExclusionList.contains { $0.id == tabCard.id })


### PR DESCRIPTION
Saw quite a few crash report on this force unwrapping here. Not sure if the force unwrapping is intended; if not, this removes it.

## Checklists

### How was this tested?
- [ ] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

### Manual test cases
I didn't test this. Not sure how to reproduce a tab for which `TabManager.get(for:)` fails.

### Screenshots and screen recordings

## Issues addressed
