### PR TITLE
Plumbing to add apple oauth authentication code to /login-mobile calls

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1657,8 +1657,11 @@ extension BrowserViewController {
                     self.introViewModel = nil
 
                     switch action {
-                    case .signupWithApple(let marketingEmailOptOut, let identityToken, let authorizationCode):
-                        if let identityToken = identityToken, let authorizationCode = authorizationCode {
+                    case .signupWithApple(
+                        let marketingEmailOptOut, let identityToken, let authorizationCode):
+                        if let identityToken = identityToken,
+                            let authorizationCode = authorizationCode
+                        {
                             let authURL = NeevaConstants.appleAuthURL(
                                 identityToken: identityToken,
                                 authorizationCode: authorizationCode,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1657,19 +1657,14 @@ extension BrowserViewController {
                     self.introViewModel = nil
 
                     switch action {
-                    case .signupWithApple(let marketingEmailOptOut, let serverAuthCode):
-                        if let serverAuthCode = serverAuthCode {
+                    case .signupWithApple(let marketingEmailOptOut, let identityToken, let authorizationCode):
+                        if identityToken != nil && authorizationCode != nil {
                             let authURL = NeevaConstants.appleAuthURL(
-                                serverAuthCode: serverAuthCode,
+                                identityToken: identityToken!,
+                                authorizationCode: authorizationCode!,
                                 marketingEmailOptOut: marketingEmailOptOut ?? false,
                                 signup: true)
-                            let httpCookieStore = self.tabManager.configuration.websiteDataStore
-                                .httpCookieStore
-                            httpCookieStore.setCookie(
-                                NeevaConstants.serverAuthCodeCookie(for: serverAuthCode)
-                            ) {
-                                self.openURLInNewTab(authURL)
-                            }
+                            self.openURLInNewTab(authURL)
                         }
                     case .skipToBrowser:
                         if let onDismiss = onDismiss {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1658,10 +1658,10 @@ extension BrowserViewController {
 
                     switch action {
                     case .signupWithApple(let marketingEmailOptOut, let identityToken, let authorizationCode):
-                        if identityToken != nil && authorizationCode != nil {
+                        if let identityToken = identityToken, let authorizationCode = authorizationCode {
                             let authURL = NeevaConstants.appleAuthURL(
-                                identityToken: identityToken!,
-                                authorizationCode: authorizationCode!,
+                                identityToken: identityToken,
+                                authorizationCode: authorizationCode,
                                 marketingEmailOptOut: marketingEmailOptOut ?? false,
                                 signup: true)
                             self.openURLInNewTab(authURL)

--- a/Client/Frontend/Intro/IntroFirstRunView.swift
+++ b/Client/Frontend/Intro/IntroFirstRunView.swift
@@ -43,7 +43,7 @@ struct FirstRunHomePage: View {
                         color: .black
                     ) {
                         logFirstRunSignUpWithAppleClick()
-                        model.buttonAction(.signupWithApple(model.marketingEmailOptOut, nil))
+                        model.buttonAction(.signupWithApple(model.marketingEmailOptOut, nil, nil))
                     }
 
                     IntroButton(icon: nil, label: "Other sign up options", color: .brand.blue) {

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -225,7 +225,8 @@ extension IntroViewModel: ASAuthorizationControllerDelegate {
                     attributes: EnvironmentHelper.shared.getFirstRunAttributes()
                 )
             }
-            self.onDismiss(.signupWithApple(self.marketingEmailOptOut, identityTokenStr, authorizationCodeStr))
+            self.onDismiss(
+                .signupWithApple(self.marketingEmailOptOut, identityTokenStr, authorizationCodeStr))
             break
         default:
             break

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -9,6 +9,8 @@ import Defaults
 import Shared
 import UIKit
 
+private let log = Logger.auth
+
 enum FirstRunButtonActions {
     case signin
     case signupWithApple(Bool?, String?, String?)
@@ -200,19 +202,19 @@ extension IntroViewModel: ASAuthorizationControllerDelegate {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             // redirect and create account
             guard let identityToken = appleIDCredential.identityToken else {
-                print("Unable to fetch identity token")
+                log.error("Unable to fetch identity token")
                 return
             }
             guard let authorizationCode = appleIDCredential.authorizationCode else {
-                print("Unable to fetch authorization code")
+                log.error("Unable to fetch authorization code")
                 return
             }
             guard let identityTokenStr = String(data: identityToken, encoding: .utf8) else {
-                print("Unable to convert identity token to utf8")
+                log.error("Unable to convert identity token to utf8")
                 return
             }
             guard let authorizationCodeStr = String(data: authorizationCode, encoding: .utf8) else {
-                print("Unable to convert authorization code to utf8")
+                log.error("Unable to convert authorization code to utf8")
                 return
             }
 

--- a/Client/Frontend/Intro/OtherOptionsPage.swift
+++ b/Client/Frontend/Intro/OtherOptionsPage.swift
@@ -236,7 +236,7 @@ struct OtherOptionsPage: View {
                     SignUpWithAppleButton(
                         action: {
                             logOtherOptionsSignUpWithAppleClick()
-                            model.buttonAction(.signupWithApple(model.marketingEmailOptOut, nil))
+                            model.buttonAction(.signupWithApple(model.marketingEmailOptOut, nil, nil))
                         }, onSignInMode: $model.onSignInMode
                     )
 

--- a/Client/Frontend/Intro/OtherOptionsPage.swift
+++ b/Client/Frontend/Intro/OtherOptionsPage.swift
@@ -236,7 +236,8 @@ struct OtherOptionsPage: View {
                     SignUpWithAppleButton(
                         action: {
                             logOtherOptionsSignUpWithAppleClick()
-                            model.buttonAction(.signupWithApple(model.marketingEmailOptOut, nil, nil))
+                            model.buttonAction(
+                                .signupWithApple(model.marketingEmailOptOut, nil, nil))
                         }, onSignInMode: $model.onSignInMode
                     )
 

--- a/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
+++ b/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
@@ -6,6 +6,8 @@ import AuthenticationServices
 import Shared
 import SwiftUI
 
+private let log = Logger.auth
+
 struct SignUpTwoButtonsPromptViewOverlayContent: View {
     var query: String
     var skippable: Bool
@@ -132,19 +134,19 @@ struct SignUpTwoButtonsPromptView: View {
                         // redirect and create account
                         // TODO(Seth): ideally reduce the code duplication here with IntroViewModel lines 200-217
                         guard let identityToken = appleIDCredential.identityToken else {
-                            print("Unable to fetch identity token")
+                            log.error("Unable to fetch identity token")
                             return
                         }
                         guard let authorizationCode = appleIDCredential.authorizationCode else {
-                            print("Unable to fetch authorization code")
+                            log.error("Unable to fetch authorization code")
                             return
                         }
                         guard let identityTokenStr = String(data: identityToken, encoding: .utf8) else {
-                            print("Unable to convert identity token to utf8")
+                            log.error("Unable to convert identity token to utf8")
                             return
                         }
                         guard let authorizationCodeStr = String(data: authorizationCode, encoding: .utf8) else {
-                            print("Unable to convert authorization code to utf8")
+                            log.error("Unable to convert authorization code to utf8")
                             return
                         }
 

--- a/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
+++ b/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
@@ -141,11 +141,15 @@ struct SignUpTwoButtonsPromptView: View {
                             log.error("Unable to fetch authorization code")
                             return
                         }
-                        guard let identityTokenStr = String(data: identityToken, encoding: .utf8) else {
+                        guard let identityTokenStr = String(data: identityToken, encoding: .utf8)
+                        else {
                             log.error("Unable to convert identity token to utf8")
                             return
                         }
-                        guard let authorizationCodeStr = String(data: authorizationCode, encoding: .utf8) else {
+                        guard
+                            let authorizationCodeStr = String(
+                                data: authorizationCode, encoding: .utf8)
+                        else {
                             log.error("Unable to convert authorization code to utf8")
                             return
                         }

--- a/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
+++ b/Client/Frontend/Intro/SignUpTwoButtonsPromptView.swift
@@ -130,21 +130,34 @@ struct SignUpTwoButtonsPromptView: View {
                     switch auth.credential {
                     case let appleIDCredential as ASAuthorizationAppleIDCredential:
                         // redirect and create account
-                        let token = appleIDCredential.identityToken
-
-                        if token != nil {
-                            if let authStr = String(data: token!, encoding: .utf8) {
-                                let authURL = NeevaConstants.appleAuthURL(
-                                    serverAuthCode: authStr,
-                                    marketingEmailOptOut: self.marketingEmailOptOut,
-                                    signup: true)
-                                ClientLogger.shared.logCounter(
-                                    .PreviewPromptSignupWithApple,
-                                    attributes: EnvironmentHelper.shared.getFirstRunAttributes())
-                                hideOverlay()
-                                openInNewTab(authURL, false)
-                            }
+                        // TODO(Seth): ideally reduce the code duplication here with IntroViewModel lines 200-217
+                        guard let identityToken = appleIDCredential.identityToken else {
+                            print("Unable to fetch identity token")
+                            return
                         }
+                        guard let authorizationCode = appleIDCredential.authorizationCode else {
+                            print("Unable to fetch authorization code")
+                            return
+                        }
+                        guard let identityTokenStr = String(data: identityToken, encoding: .utf8) else {
+                            print("Unable to convert identity token to utf8")
+                            return
+                        }
+                        guard let authorizationCodeStr = String(data: authorizationCode, encoding: .utf8) else {
+                            print("Unable to convert authorization code to utf8")
+                            return
+                        }
+
+                        let authURL = NeevaConstants.appleAuthURL(
+                            identityToken: identityTokenStr,
+                            authorizationCode: authorizationCodeStr,
+                            marketingEmailOptOut: self.marketingEmailOptOut,
+                            signup: true)
+                        ClientLogger.shared.logCounter(
+                            .PreviewPromptSignupWithApple,
+                            attributes: EnvironmentHelper.shared.getFirstRunAttributes())
+                        hideOverlay()
+                        openInNewTab(authURL, false)
                         break
                     default:
                         break

--- a/Shared/NeevaConstants.swift
+++ b/Shared/NeevaConstants.swift
@@ -199,8 +199,6 @@ public struct NeevaConstants {
             URLQueryItem(name: "signup", value: String(signup)),
             URLQueryItem(name: "ignoreCountryCode", value: "true"),
         ]
-        // DO NOT SUBMIT
-        print("Apple AUTH URL: \(authURL.withQueryParams(queryItems))")
         return authURL.withQueryParams(queryItems)
     }
 

--- a/Shared/NeevaConstants.swift
+++ b/Shared/NeevaConstants.swift
@@ -152,21 +152,6 @@ public struct NeevaConstants {
         ])!
     }
 
-    /// Generates a serverAuthCodeCookie cookie from the given cookie value.
-    public static func serverAuthCodeCookie(for value: String) -> HTTPCookie {
-        HTTPCookie(properties: [
-            .name: "serverAuthCode",
-            .value: value,
-            .domain: NeevaConstants.appHost,
-            .path: "/",
-            .expires: Date() + 1 * 60,
-            .secure: true,
-            .sameSitePolicy: HTTPCookieStringPolicy.sameSiteLax,
-            // ! potentially undocumented API
-            .init("HttpOnly"): true,
-        ])!
-    }
-
     public static let sharedBundle = Bundle(for: BundleHookClass.self)
 
     public static func isNeevaHome(url: URL?) -> Bool {
@@ -200,18 +185,22 @@ public struct NeevaConstants {
 
     // Construct auth url for signin with apple
     public static func appleAuthURL(
-        serverAuthCode: String,
+        identityToken: String,
+        authorizationCode: String,
         marketingEmailOptOut: Bool,
         signup: Bool
     ) -> URL {
         let authURL = buildAppURL("login-mobile")
         let queryItems: [URLQueryItem] = [
             URLQueryItem(name: "provider", value: "neeva.co/auth/oauth2/authenticators/apple"),
-            URLQueryItem(name: "serverAuthCode", value: serverAuthCode),
+            URLQueryItem(name: "identityToken", value: identityToken),
+            URLQueryItem(name: "authorizationCode", value: authorizationCode),
             URLQueryItem(name: "mktEmailOptOut", value: String(marketingEmailOptOut)),
             URLQueryItem(name: "signup", value: String(signup)),
             URLQueryItem(name: "ignoreCountryCode", value: "true"),
         ]
+        // DO NOT SUBMIT
+        print("Apple AUTH URL: \(authURL.withQueryParams(queryItems))")
         return authURL.withQueryParams(queryItems)
     }
 


### PR DESCRIPTION
After completing the native Apple oauth flow, we were previously only sending back the `identityToken` to the `/login-mobile` endpoint. We passed this as the `serverAuthCode` URL param.

With this change, we:

1. Rename the `serverAuthCode` URL param to `identityToken`, for clarity (the server API will still accept either param, preferring `identityToken` over `serverAuthCode` if both are set)
2. Add the authentication code to this request, as the new `authenticationCode` URL param.

The authentication code is used by httpd to exchange with Apple's servers for an authentication token, which is then encrypted and stored in mysql. A daily job (usertable-cleanauth) runs to verify the token has not been revoked by the user. See this doc for more details: https://docs.google.com/document/d/1F8Kwpexb481eIOBXxVuK9noBVCR8cHfZQR7HL6g06IA.

I also removed some legacy logic that was storing the identity token in a cookie, after verifying no code in httpd reads this cookie.

## Checklists

### How was this tested?
- [ ] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

### Manual test cases
If manually tested, describe the different scenarios you followed to ensure
that your changes work.  Make sure that you've tested as many pathways as
possible -- not just the [happy path](https://en.wikipedia.org/wiki/Happy_path).

### Screenshots and screen recordings
Images or videos showing the effect of your PR.  Examples include:
* For new Views, add images of `_Previews` you have added for both light
  and dark mode
* Before and after screenshots showing the effect of your styling changes
* Videos showing you performing the flow that you have changed

## Issues addressed
* Link(s) to Github issue(s) (if applicable)
