### PR TITLE
Cookie Cutter UI P2

### DIFF
--- a/Client/Extensions/Environment.swift
+++ b/Client/Extensions/Environment.swift
@@ -92,4 +92,12 @@ extension EnvironmentValues {
         get { self[SafeAreaKey.self] }
         set { self[SafeAreaKey.self] = newValue }
     }
+
+    private struct OpenSettingsKey: EnvironmentKey {
+        static var defaultValue: (() -> Void) = {}
+    }
+    public var openSettings: (() -> Void) {
+        get { self[OpenSettingsKey.self] }
+        set { self[OpenSettingsKey.self] = newValue }
+    }
 }

--- a/Client/Frontend/Browser/BrowserModel.swift
+++ b/Client/Frontend/Browser/BrowserModel.swift
@@ -29,6 +29,7 @@ class BrowserModel: ObservableObject {
     var contentVisibilityModel: ContentVisibilityModel
     var scrollingControlModel: ScrollingControlModel
     let switcherToolbarModel: SwitcherToolbarModel
+    let cookieCutterModel = CookieCutterModel()
 
     func show() {
         if gridModel.switcherState != .tabs {

--- a/Client/Frontend/Browser/BrowserTopBarView.swift
+++ b/Client/Frontend/Browser/BrowserTopBarView.swift
@@ -61,6 +61,11 @@ struct BrowserTopBarView: View {
                         bvc.hideZeroQuery()
                     }
                 }
+            ).environment(
+                \.openSettings,
+                {
+                    bvc.openSettings(openPage: .cookieCutter)
+                }
             )
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2182,3 +2182,21 @@ extension BrowserViewController {
                     })))
     }
 }
+
+extension BrowserViewController {
+    func openSettings(openPage: SettingsPage? = nil) {
+        let action = {
+            let controller = SettingsViewController(bvc: self, openPage: openPage)
+            self.present(controller, animated: true)
+        }
+
+        TourManager.shared.userReachedStep(tapTarget: .settingMenu)
+
+        // For the connected apps tour prompt
+        if let presentedViewController = presentedViewController {
+            presentedViewController.dismiss(animated: true, completion: action)
+        } else {
+            action()
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+OverflowMenu.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+OverflowMenu.swift
@@ -124,17 +124,8 @@ extension BrowserViewController {
                 .OpenSetting,
                 attributes: EnvironmentHelper.shared.getAttributes() + [overflowMenuAttribute]
             )
-            let action = {
-                let controller = SettingsViewController(bvc: self)
-                self.present(controller, animated: true)
-            }
-            TourManager.shared.userReachedStep(tapTarget: .settingMenu)
-            // For the connected apps tour prompt
-            if let presentedViewController = presentedViewController {
-                presentedViewController.dismiss(animated: true, completion: action)
-            } else {
-                action()
-            }
+
+            openSettings()
         case .goToHistory:
             ClientLogger.shared.logCounter(
                 .OpenHistory,

--- a/Client/Frontend/Overlay/Content/Menu/TrackingProtection/TrackingMenuProtectionRowButton.swift
+++ b/Client/Frontend/Overlay/Content/Menu/TrackingProtection/TrackingMenuProtectionRowButton.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 public struct TrackingMenuProtectionRowButton: View {
     @Binding var preventTrackers: Bool
+    @Environment(\.openSettings) var openSettings
 
     public var body: some View {
         GroupedCell.Decoration {
@@ -36,7 +37,7 @@ public struct TrackingMenuProtectionRowButton: View {
 
                 if FeatureFlag[.cookieCutter] {
                     Button {
-                        // TODO: Open Settings
+                        openSettings()
                     } label: {
                         HStack {
                             Text("Cookie Cutter Settings")

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -96,3 +96,11 @@ class ConnectedDAppsClearable: Clearable {
         return succeed()
     }
 }
+
+class CookieCutterExclusionsClearable: Clearable {
+    func clear() -> Success {
+        // TODO: Actually clear this data
+        let result = Success()
+        return result
+    }
+}

--- a/Client/Frontend/Settings/CookieCutter/CookieCutterSettings.swift
+++ b/Client/Frontend/Settings/CookieCutter/CookieCutterSettings.swift
@@ -7,10 +7,10 @@ import Shared
 import SwiftUI
 
 struct CookieCutterSettings: View {
-    @Default(.contentBlockingEnabled) private var contentBlockingEnabled
-
+    @Environment(\.onOpenURL) var openURL
     @EnvironmentObject var cookieCutterModel: CookieCutterModel
 
+    @Default(.contentBlockingEnabled) private var contentBlockingEnabled
     @State var showNonEssentialCookieSettings = false
 
     var body: some View {
@@ -24,7 +24,7 @@ struct CookieCutterSettings: View {
                         )
 
                         Button {
-                            // TODO: Link to learn more page
+                            openURL(NeevaConstants.cookieCutterHelpURL)
                         } label: {
                             Text("Learn More")
                         }

--- a/Client/Frontend/Settings/Privacy/DataManagementView.swift
+++ b/Client/Frontend/Settings/Privacy/DataManagementView.swift
@@ -13,6 +13,7 @@ enum ClearableDataType: String, Identifiable, Codable, CaseIterable {
     case cookies = "Cookies"
     case trackingProtection = "Tracking Protection"
     case dapps = "Connected dApps"
+    case cookieCutterExclusions = "Cookie Cutter Exclusions"
 
     var id: String { rawValue }
 
@@ -24,6 +25,7 @@ enum ClearableDataType: String, Identifiable, Codable, CaseIterable {
         case .cookies: return "Cookies"
         case .trackingProtection: return "Tracking Protection"
         case .dapps: return "Connected dApps"
+        case .cookieCutterExclusions: return "Cookie Cutter Exclusions"
         }
     }
 
@@ -31,6 +33,8 @@ enum ClearableDataType: String, Identifiable, Codable, CaseIterable {
         switch self {
         case .cookies:
             return "Clearing it will sign you out of most sites."
+        case .cookieCutterExclusions:
+            return "List of sites you configured to not use Cookie Cutter"
         default:
             return nil
         }
@@ -48,6 +52,8 @@ enum ClearableDataType: String, Identifiable, Codable, CaseIterable {
             return TrackingProtectionClearable()
         case .dapps:
             return ConnectedDAppsClearable()
+        case .cookieCutterExclusions:
+            return CookieCutterExclusionsClearable()
         }
     }
 }
@@ -83,7 +89,16 @@ struct DataManagementView: View {
             Section(header: Text("Data on This Device")) {
                 ForEach(
                     ClearableDataType.allCases.filter {
-                        $0 == .dapps ? NeevaConstants.currentTarget == .xyz : true
+                        switch $0 {
+                        case .trackingProtection:
+                            return !FeatureFlag[.cookieCutter]
+                        case .dapps:
+                            return NeevaConstants.currentTarget == .xyz
+                        case .cookieCutterExclusions:
+                            return FeatureFlag[.cookieCutter]
+                        default:
+                            return true
+                        }
                     }
                 ) { dataType in
                     Toggle(

--- a/Client/Frontend/Settings/Privacy/PrivacySettingsSection.swift
+++ b/Client/Frontend/Settings/Privacy/PrivacySettingsSection.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct PrivacySettingsSection: View {
     @State var openCookieCutterPage = false
-    
+
     @Default(.closeIncognitoTabs) var closeIncognitoTabs
     @Default(.contentBlockingEnabled) private var contentBlockingEnabled
     @Environment(\.onOpenURL) var openURL

--- a/Client/Frontend/Settings/Privacy/PrivacySettingsSection.swift
+++ b/Client/Frontend/Settings/Privacy/PrivacySettingsSection.swift
@@ -7,9 +7,12 @@ import Shared
 import SwiftUI
 
 struct PrivacySettingsSection: View {
+    @State var openCookieCutterPage = false
+    
     @Default(.closeIncognitoTabs) var closeIncognitoTabs
     @Default(.contentBlockingEnabled) private var contentBlockingEnabled
     @Environment(\.onOpenURL) var openURL
+    @EnvironmentObject var browserModel: BrowserModel
 
     var body: some View {
         NavigationLink(
@@ -58,9 +61,12 @@ struct PrivacySettingsSection: View {
         }
 
         if FeatureFlag[.cookieCutter] {
-            NavigationLink(
-                "Cookie Cutter",
-                destination: CookieCutterSettings().environmentObject(CookieCutterModel()))
+            NavigationLink(isActive: $openCookieCutterPage) {
+                CookieCutterSettings()
+                    .environmentObject(browserModel.cookieCutterModel)
+            } label: {
+                Text("Cookie Cutter")
+            }
         }
 
         NavigationLinkButton("Privacy Policy") {

--- a/Client/Frontend/Settings/SettingsView.swift
+++ b/Client/Frontend/Settings/SettingsView.swift
@@ -17,8 +17,13 @@ extension EnvironmentValues {
     }
 }
 
+enum SettingsPage {
+    case cookieCutter
+}
+
 struct SettingsView: View {
     let dismiss: () -> Void
+    let openPage: SettingsPage?
 
     #if DEBUG
         @State var showDebugSettings = true
@@ -40,7 +45,7 @@ struct SettingsView: View {
                     GeneralSettingsSection()
                 }
                 Section(header: Text("Privacy")) {
-                    PrivacySettingsSection()
+                    PrivacySettingsSection(openCookieCutterPage: openPage == .cookieCutter)
                 }
                 Section(header: Text("Support")) {
                     SupportSettingsSection()
@@ -87,11 +92,11 @@ struct SettingPreviewWrapper<Content: View>: View {
 }
 
 class SettingsViewController: UIHostingController<AnyView> {
-    init(bvc: BrowserViewController) {
+    init(bvc: BrowserViewController, openPage: SettingsPage? = nil) {
         super.init(rootView: AnyView(EmptyView()))
 
         self.rootView = AnyView(
-            SettingsView(dismiss: { self.dismiss(animated: true, completion: nil) })
+            SettingsView(dismiss: { self.dismiss(animated: true, completion: nil) }, openPage: openPage)
                 .environment(\.openInNewTab) { url, isIncognito in
                     self.dismiss(animated: true, completion: nil)
                     bvc.openURLInNewTab(url, isIncognito: isIncognito)
@@ -122,6 +127,7 @@ class SettingsViewController: UIHostingController<AnyView> {
                     } onDismiss: {
                     }
                 }
+                .environmentObject(bvc.browserModel)
         )
     }
 
@@ -132,6 +138,6 @@ class SettingsViewController: UIHostingController<AnyView> {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView(dismiss: {})
+        SettingsView(dismiss: {}, openPage: nil)
     }
 }

--- a/Client/Frontend/Settings/SettingsView.swift
+++ b/Client/Frontend/Settings/SettingsView.swift
@@ -96,38 +96,40 @@ class SettingsViewController: UIHostingController<AnyView> {
         super.init(rootView: AnyView(EmptyView()))
 
         self.rootView = AnyView(
-            SettingsView(dismiss: { self.dismiss(animated: true, completion: nil) }, openPage: openPage)
-                .environment(\.openInNewTab) { url, isIncognito in
-                    self.dismiss(animated: true, completion: nil)
-                    bvc.openURLInNewTab(url, isIncognito: isIncognito)
+            SettingsView(
+                dismiss: { self.dismiss(animated: true, completion: nil) }, openPage: openPage
+            )
+            .environment(\.openInNewTab) { url, isIncognito in
+                self.dismiss(animated: true, completion: nil)
+                bvc.openURLInNewTab(url, isIncognito: isIncognito)
+            }
+            .environment(\.onOpenURL) { url in
+                self.dismiss(animated: true, completion: nil)
+                bvc.openURLInNewTabPreservingIncognitoState(url)
+            }
+            .environment(\.settingsPresentIntroViewController) {
+                self.dismiss(animated: true) {
+                    bvc.presentIntroViewController(
+                        true,
+                        completion: {
+                            bvc.hideZeroQuery()
+                        })
                 }
-                .environment(\.onOpenURL) { url in
-                    self.dismiss(animated: true, completion: nil)
-                    bvc.openURLInNewTabPreservingIncognitoState(url)
+            }
+            .environment(\.dismissScreen) {
+                self.dismiss(animated: true, completion: nil)
+            }
+            .environment(\.showNotificationPrompt) {
+                bvc.showAsModalOverlaySheet(
+                    style: OverlayStyle(
+                        showTitle: false,
+                        backgroundColor: .systemBackground)
+                ) {
+                    NotificationPromptViewOverlayContent()
+                } onDismiss: {
                 }
-                .environment(\.settingsPresentIntroViewController) {
-                    self.dismiss(animated: true) {
-                        bvc.presentIntroViewController(
-                            true,
-                            completion: {
-                                bvc.hideZeroQuery()
-                            })
-                    }
-                }
-                .environment(\.dismissScreen) {
-                    self.dismiss(animated: true, completion: nil)
-                }
-                .environment(\.showNotificationPrompt) {
-                    bvc.showAsModalOverlaySheet(
-                        style: OverlayStyle(
-                            showTitle: false,
-                            backgroundColor: .systemBackground)
-                    ) {
-                        NotificationPromptViewOverlayContent()
-                    } onDismiss: {
-                    }
-                }
-                .environmentObject(bvc.browserModel)
+            }
+            .environmentObject(bvc.browserModel)
         )
     }
 

--- a/Client/Frontend/TabChrome/TopBar/LocationView/TabLocationBarButton.swift
+++ b/Client/Frontend/TabChrome/TopBar/LocationView/TabLocationBarButton.swift
@@ -21,6 +21,8 @@ struct TabLocationBarButton<Label: View>: View {
 
 struct LocationViewTrackingButton: View {
     @State private var showingPopover = false
+
+    @Environment(\.openSettings) private var openSettings
     @EnvironmentObject private var incognitoModel: IncognitoModel
     @EnvironmentObject private var trackingStatsModel: TrackingStatsViewModel
 
@@ -42,6 +44,7 @@ struct LocationViewTrackingButton: View {
             arrowDirections: [.up, .down]
         ) {
             TrackingMenuView().environmentObject(trackingStatsModel)
+                .environment(\.openSettings, openSettings)
         }
     }
 }

--- a/Shared/NeevaConstants.swift
+++ b/Shared/NeevaConstants.swift
@@ -58,6 +58,8 @@ public struct NeevaConstants {
     public static let appHelpCenterURL: URL = "https://help.neeva.com/"
     public static let appPrivacyURL = appMarketingURL / "privacy"
     public static let appTermsURL = appMarketingURL / "terms"
+    public static let cookieCutterHelpURL: URL =
+        "https://help.neeva.com/hc/en-us/articles/4486326606355"
 
     public static var xyzURL: URL {
         URL(string: "https://neeva.xyz/\(Defaults[.cryptoPublicKey])") ?? "https://neeva.xyz/"


### PR DESCRIPTION
- Added the ability to open the Cookie Cutter settings from the tracking menu
- Link the `learn more` button
- Update the `Tracking UI`

## Checklists
### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

## Issues addressed
Issue: #3282
