### PR TITLE
Fixes empty header space by using Group instead of DecorativeSection

### DIFF
--- a/Client/Frontend/Settings/Privacy/WebsiteDataView.swift
+++ b/Client/Frontend/Settings/Privacy/WebsiteDataView.swift
@@ -87,7 +87,7 @@ struct WebsiteDataView: View {
                         LoadingView("Loading data…", mini: true)
                     }
                 }
-                DecorativeSection {
+                Group {
                     HStack {
                         Spacer(minLength: 0)
                         Button("Clear All Website Data") { isDeleting = true }


### PR DESCRIPTION
There was some empty space above the "Clear All Website Data" button. This may be a bug in SwiftUI's `Section`. This PR simply uses `Group` instead of `DecorativeSection` to fix the spacing.

## Checklists

### How was this tested?
- [x] I tested this manually

### Manual test cases

I built and ran the app in the Simulator to confirm.

### Screenshots and screen recordings

![before-and-after](https://user-images.githubusercontent.com/979929/162097587-e3182848-5ab2-499b-807f-f6fabcf511c4.png)

## Issues addressed

Related to #1015