### PR TITLE
Prototype moving scrollTo calls earlier

### DIFF
--- a/Client/Frontend/Browser/BrowserModel.swift
+++ b/Client/Frontend/Browser/BrowserModel.swift
@@ -41,13 +41,16 @@ class BrowserModel: ObservableObject {
         if gridModel.tabCardModel.allDetails.isEmpty {
             showWithNoAnimation()
         } else {
-            cardTransitionModel.update(to: .visibleForTrayShow)
-            contentVisibilityModel.update(showContent: false)
-            updateSpaces()
+            gridModel.scrollToSelectedTab { [self] in
+                cardTransitionModel.update(to: .visibleForTrayShow)
+                contentVisibilityModel.update(showContent: false)
+                updateSpaces()
+            }
         }
     }
 
     func showWithNoAnimation() {
+        gridModel.scrollToSelectedTab()
         cardTransitionModel.update(to: .hidden)
         contentVisibilityModel.update(showContent: false)
         if !showGrid {
@@ -69,12 +72,14 @@ class BrowserModel: ObservableObject {
 
     func hideWithAnimation() {
         assert(!gridModel.tabCardModel.allDetails.isEmpty)
-        cardTransitionModel.update(to: .visibleForTrayHidden)
-
-        gridModel.closeDetailView()
+        gridModel.scrollToSelectedTab { [self] in
+            cardTransitionModel.update(to: .visibleForTrayHidden)
+            gridModel.closeDetailView()
+        }
     }
 
     func hideWithNoAnimation() {
+        gridModel.scrollToSelectedTab()
         cardTransitionModel.update(to: .hidden)
 
         if showGrid {

--- a/Client/Frontend/Browser/Card/CardGrid.swift
+++ b/Client/Frontend/Browser/Card/CardGrid.swift
@@ -37,23 +37,17 @@ struct CardGridBackground: View {
                 for: browserModel.showGrid,
                 completion: browserModel.onCompletedCardTransition
             )
-            .useEffect(deps: cardTransitionModel.state) { _ in
+            .useEffect(deps: cardTransitionModel.state) { state in
                 // Ensure that the `Card` for the selected tab is visible. This way its
                 // `CardTransitionModifier` will be visible and run the animation.
-                if cardTransitionModel.state != .hidden {
-                    if !tabModel.allDetails.isEmpty {
-                        gridModel.scrollToSelectedTab()
-                    }
+                if state != .hidden {
                     // Allow some time for the `Card` to get created if it was previously
                     // not visible. Compute `showGrid` before the the delay since the
                     // card transition animation could complete before the callback runs.
-                    let showGrid =
-                        (cardTransitionModel.state == .visibleForTrayShow)
-                    DispatchQueue.main.async {
-                        if browserModel.showGrid != showGrid {
-                            withAnimation(CardTransitionUX.animation) {
-                                browserModel.showGrid = showGrid
-                            }
+                    let showGrid = (state == .visibleForTrayShow)
+                    if browserModel.showGrid != showGrid {
+                        withAnimation(CardTransitionUX.animation) {
+                            browserModel.showGrid = showGrid
                         }
                     }
                 }

--- a/Client/Frontend/Browser/Card/CardsContainer.swift
+++ b/Client/Frontend/Browser/Card/CardsContainer.swift
@@ -45,16 +45,6 @@ struct TabGridContainer: View {
             : tabModel.normalRows.first { $0.cells.contains(where: \.isSelected) }?.id
     }
 
-    var selectedCardID: String? {
-        if let details = tabModel.allDetailsWithExclusionList.first(where: \.isSelected) {
-            return details.id
-        }
-        if let details = tabModel.allTabGroupDetails.first(where: \.isSelected) {
-            return details.id
-        }
-        return nil
-    }
-
     var body: some View {
         Group {
             LazyVStack(alignment: .leading, spacing: 0) {
@@ -68,6 +58,10 @@ struct TabGridContainer: View {
                 withAnimation(nil) {
                     scrollProxy.scrollTo(selectedRowId)
                 }
+            }
+            if let completion = gridModel.scrollToCompletion {
+                gridModel.scrollToCompletion = nil
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: completion)
             }
         }
         .animation(nil)

--- a/Client/Frontend/Browser/Card/GridModel.swift
+++ b/Client/Frontend/Browser/Card/GridModel.swift
@@ -32,6 +32,7 @@ class GridModel: ObservableObject {
         }
     }
     @Published var needsScrollToSelectedTab: Int = 0
+    var scrollToCompletion: (() -> Void)?
 
     // Spaces
     @Published var isLoading = false
@@ -55,7 +56,8 @@ class GridModel: ObservableObject {
         return tabManager.normalTabs.isEmpty
     }
 
-    func scrollToSelectedTab() {
+    func scrollToSelectedTab(completion: (() -> Void)? = nil) {
+        scrollToCompletion = completion
         needsScrollToSelectedTab += 1
     }
 


### PR DESCRIPTION
@chassu - Here's an exploration of moving the scrollTo calls earlier and delaying other steps, involved in transitioning between content and cardgrid, until after the scrollTo has happened. This uses a dreaded `asyncAfter` so I'm not happy about it. The consequential change here is moving scrollTo ahead of other work related to the transition. I'm curious how this would impact the issue we were seeing on your PR.