### PR TITLE
Fix Logging Crash When Opening NeevaScope

### DIFF
--- a/Client/Logging/ClientLogger.swift
+++ b/Client/Logging/ClientLogger.swift
@@ -69,7 +69,9 @@ public class ClientLogger {
 
         #if DEBUG
             if !Defaults[.forceProdGraphQLLogger] {
-                let attributes = loggingAttributes.map { "\($0.key! ?? "" ): \($0.value! ?? "")" }
+                let attributes = loggingAttributes.compactMap {
+                    "\(String(describing: $0.key)): \(String(describing: $0.value))"
+                }
                 let path = path.rawValue
                 debugLoggerHistory.insert(
                     DebugLog(


### PR DESCRIPTION
Logging when opening NeevaScope for the first time would sometimes crash. This unwraps the values to make sure that it doesn't crash.

FYI @chassu and @EdwardJTL 

## Checklists
### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes