### PR TITLE
Correctly Pass Auth Cookie

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+IntroView.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+IntroView.swift
@@ -98,11 +98,9 @@ extension BrowserViewController {
                 .registerDeviceTokenWithServer(deviceToken: notificationToken)
         }
 
-        let httpCookieStore = self.tabManager.configuration.websiteDataStore.httpCookieStore
-        httpCookieStore.setCookie(NeevaConstants.loginCookie(for: token)) {
-            DispatchQueue.main.async {
-                self.openURLFromAuth(url)
-            }
+        NeevaUserInfo.shared.setLoginCookie(token)
+        DispatchQueue.main.async {
+            self.openURLFromAuth(url)
         }
     }
 

--- a/Shared/API/NeevaUserInfo.swift
+++ b/Shared/API/NeevaUserInfo.swift
@@ -115,6 +115,10 @@ public class NeevaUserInfo: ObservableObject {
         }
     }
 
+    public func updateLoginCookie(with token: String) {
+        self.setLoginCookie(token)
+    }
+
     public func setLoginCookie(_ value: String) {
         // check if token has changed, when different, save new token
         // and fetch user info


### PR DESCRIPTION
Instead of setting the token via the `WebView`, we can pass it directly to `UserInfo`.

### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

## Issues addressed
Fixed: #3367
