### PR TITLE
First navigation logging

### DIFF
--- a/Client/AppConfig.xcconfig
+++ b/Client/AppConfig.xcconfig
@@ -5,5 +5,5 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-BROWSER_PROJECT_VERSION = 214
-BROWSER_MARKETING_VERSION = 1.39.2
+BROWSER_PROJECT_VERSION = 215
+BROWSER_MARKETING_VERSION = 1.40.0

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1097,6 +1097,9 @@ class BrowserViewController: UIViewController, ModalPresenter {
             return
         }
 
+        if !Defaults[.didFirstNavigation] {
+            ClientLogger.shared.logCounter(.FirstNavigation)
+        }
         Defaults[.didFirstNavigation] = true
 
         if let url = webView.url {

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -201,6 +201,8 @@ public struct LogConfig {
         /// Request AttributionToken error
         case ResolvedAttributionTokenError
         case ResolvedAttributionTokenRetryError
+        /// Log first navigation
+        case FirstNavigation
 
         // MARK: promo card
         /// Promo card is rendered on screen
@@ -543,6 +545,7 @@ public struct LogConfig {
         case .ResolvedAttributionToken: return .FirstRun
         case .ResolvedAttributionTokenError: return .FirstRun
         case .ResolvedAttributionTokenRetryError: return .FirstRun
+        case .FirstNavigation: return . FirstRun
 
         // MARK: - PromoCard
         case .PromoCardAppear: return .PromoCard

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -545,7 +545,7 @@ public struct LogConfig {
         case .ResolvedAttributionToken: return .FirstRun
         case .ResolvedAttributionTokenError: return .FirstRun
         case .ResolvedAttributionTokenRetryError: return .FirstRun
-        case .FirstNavigation: return . FirstRun
+        case .FirstNavigation: return .FirstRun
 
         // MARK: - PromoCard
         case .PromoCardAppear: return .PromoCard


### PR DESCRIPTION
Currently, we have a `FirstRunPageLoad` which is meant for navigation after first run for non-signed in user; however, that event does not seem very reliable and it got logged multiple times for one user or sometimes it's not logged at all. Instead, we should log it at the point where user starts a tab navigation which shows the user intent of navigating.

## Checklists

### How was this tested?
- [ ] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes
