### PR TITLE
suppress promo before first navigation

### DIFF
--- a/Client/Frontend/ZeroQuery/ZeroQueryModel.swift
+++ b/Client/Frontend/ZeroQuery/ZeroQueryModel.swift
@@ -252,17 +252,24 @@ class ZeroQueryModel: ObservableObject {
     }
 
     func shouldShowDefaultBrowserPromoCard() -> Bool {
+        let currentTargetIsClient = NeevaConstants.currentTarget == .client
+        let didNotDismissDefaultBrowserCard = !Defaults[.didDismissDefaultBrowserCard]
+        let didNotSetDefaultBrowser = !Defaults[.didSetDefaultBrowser]
+        let didFirstNavigation = Defaults[.didFirstNavigation]
+
         let notSeenInterstitial =
             !Defaults[.didShowDefaultBrowserInterstitial]
             && !Defaults[.didShowDefaultBrowserInterstitialFromSkipToBrowser]
+        let satisfiesFreqRule = satisfyDefaultBrowserPromoFreqRule()
+        //let lastDefaultBrowserInterstitialSkipped = DefaultBrowserInterstitialChoice(
+        //    rawValue: Defaults[.lastDefaultBrowserInterstitialChoice]) == .skipForNow
 
-        return NeevaConstants.currentTarget == .client && !Defaults[.didDismissDefaultBrowserCard]
-            && !Defaults[.didSetDefaultBrowser]
-            && Defaults[.didFirstNavigation]
+        return currentTargetIsClient
+            && didNotDismissDefaultBrowserCard
+            && didNotSetDefaultBrowser
+            && didFirstNavigation
             && (notSeenInterstitial
-                || satisfyDefaultBrowserPromoFreqRule()
-                || DefaultBrowserInterstitialChoice(
-                    rawValue: Defaults[.lastDefaultBrowserInterstitialChoice]) == .skipForNow)
+                || satisfiesFreqRule /* || lastDefaultBrowserInterstitialSkipped*/)
     }
 
     func updateSuggestedSites() {

--- a/Client/Frontend/ZeroQuery/ZeroQueryModel.swift
+++ b/Client/Frontend/ZeroQuery/ZeroQueryModel.swift
@@ -126,6 +126,10 @@ class ZeroQueryModel: ObservableObject {
     func shouldDisplayPromoCard(_ promocard: PromoCardTrigger) -> Bool {
         let promoCardTypeArm = NeevaExperiment.arm(for: .promoCardTypeAfterFirstRun)
 
+        if !Defaults[.didFirstNavigation] {
+            return false
+        }
+
         switch promocard {
         case .shouldTriggerArmDefaultPromo:
             return (promoCardTypeArm == .control || promoCardTypeArm == nil)


### PR DESCRIPTION
This PR suppresses any promos on zero query before any navigations have happened.

## Checklists

### How was this tested?
- [x] I tested this manually

### Manual test cases
I tested in the simulator.

### Screenshots and screen recordings
N/A

## Issues addressed
N/A
