### PR TITLE
Launch control arm of the default browser experiment

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -545,11 +545,6 @@ class BrowserViewController: UIViewController, ModalPresenter {
 
                 _ = NeevaExperiment.startExperiment(for: .promoCardTypeAfterFirstRun)
                 NeevaExperiment.logStartExperiment(for: .promoCardTypeAfterFirstRun)
-            } else if let didDismiss = Defaults[.didDismissDefaultBrowserInterstitial],
-                !didDismiss
-                    && !Defaults[.didFirstNavigation]
-            {
-                restoreDefaultBrowserFirstRun()
             }
         }
 


### PR DESCRIPTION
Completely go back to the control arm of the experiment so we don't restore the interstitial screen. Though we can argue restoring interstitial makes sense, we should either completely go to control or variant and we have decided to go back to control at this moment. cc @bikramneeva 

## Checklists

### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes
