### PR TITLE
Default browser interstitial button change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+IntroView.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+IntroView.swift
@@ -156,6 +156,7 @@ extension BrowserViewController {
     func restoreDefaultBrowserFirstRun() {
         let arm = NeevaExperiment.arm(for: .defaultBrowserNewScreen)
         let interstitialModel = InterstitialViewModel(
+            restoreFromBackground: true,
             isInExperimentArm: arm == .newScreen || arm == .newScreenWithVideo,
             onboardingState: .openedSettingsState,
             onCloseAction: {

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserIntestitialOnboardingView.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserIntestitialOnboardingView.swift
@@ -336,7 +336,8 @@ struct DefaultBrowserInterstitialOnboardingView: View {
                             ClientLogger.shared.logCounter(
                                 .DefaultBrowserOnboardingInterstitialOpen)
                         case .continueState:
-                            interstitialModel.openButtonText = "Open Neeva Settings"
+                            interstitialModel.openButtonText = "Back to Settings"
+                            interstitialModel.remindButtonText = "Continue to Neeva"
                             interstitialModel.showSecondaryOnboardingButton = true
                             interstitialModel.openSettingsButtonClickAction(
                                 interaction: .DefaultBrowserOnboardingInterstitialContinue


### PR DESCRIPTION
Fix #3883

And here is the change we removed the "Continue to Neeva" button for reference: https://github.com/neevaco/neeva-ios/pull/3797/files

## Checklists

### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

| Control | Arm |
| --- | --- |
| <img width="602" alt="Screen Shot 2022-06-17 at 10 24 54 AM" src="https://user-images.githubusercontent.com/87332578/174348558-9e6732ab-74fb-4838-97d4-0ee5f07f7c7b.png">  | <img width="602" alt="Screen Shot 2022-06-17 at 10 26 20 AM" src="https://user-images.githubusercontent.com/87332578/174348551-7c1a04a0-4f44-426c-bd05-94adf7e8b320.png"> |
