### PR TITLE
Tidy up LogConfig

### DIFF
--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -416,18 +416,20 @@ public struct LogConfig {
 
     private static var flagsObserver: AnyCancellable?
 
+    static let alwaysAllowedCategories: Set<InteractionCategory> = [
+        .FirstRun,
+        .Notification,
+        .Suggestions,
+        .Stability,
+        .DebugMode,
+        .PromoCard,
+        .Web3,
+        .CookieCutter,
+        .UI,
+        .OverflowMenu,
+    ]
     public static func featureFlagEnabled(for category: InteractionCategory) -> Bool {
-        if category == .FirstRun
-            || category == .Notification
-            || category == .Suggestions
-            || category == .Stability
-            || category == .DebugMode
-            || category == .PromoCard
-            || category == .Web3
-            || category == .CookieCutter
-            || category == .UI
-            || category == .OverflowMenu
-        {
+        if alwaysAllowedCategories.contains(category) {
             return true
         }
 

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -447,15 +447,15 @@ public enum LogConfig {
     }
 
     private static func updateLoggingCategory() {
-        enabledLoggingCategories?.removeAll()
-        NeevaFeatureFlags.latestValue(.loggingCategories)
-            .components(separatedBy: ",").forEach { token in
-                if let category = InteractionCategory(
-                    rawValue: token.stringByTrimmingLeadingCharactersInSet(.whitespaces)
-                ) {
-                    enabledLoggingCategories?.insert(category)
+        enabledLoggingCategories = Set(
+                NeevaFeatureFlags.latestValue(.loggingCategories)
+                .components(separatedBy: ",")
+                .compactMap { token in
+                    InteractionCategory(
+                        rawValue: token.stringByTrimmingLeadingCharactersInSet(.whitespaces)
+                    )
                 }
-            }
+            )
     }
 
     public static func shouldAddSessionID(

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -416,7 +416,7 @@ public enum LogConfig {
 
     private static var flagsObserver: AnyCancellable?
 
-    static let alwaysAllowedCategories: Set<InteractionCategory> = [
+    static let alwaysEnabledCategories: Set<InteractionCategory> = [
         .FirstRun,
         .Notification,
         .Suggestions,
@@ -429,7 +429,7 @@ public enum LogConfig {
         .OverflowMenu,
     ]
     public static func featureFlagEnabled(for category: InteractionCategory) -> Bool {
-        if alwaysAllowedCategories.contains(category) {
+        if alwaysEnabledCategories.contains(category) {
             return true
         }
 

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -448,14 +448,14 @@ public enum LogConfig {
 
     private static func updateLoggingCategory() {
         enabledLoggingCategories = Set(
-                NeevaFeatureFlags.latestValue(.loggingCategories)
+            NeevaFeatureFlags.latestValue(.loggingCategories)
                 .components(separatedBy: ",")
                 .compactMap { token in
                     InteractionCategory(
                         rawValue: token.stringByTrimmingLeadingCharactersInSet(.whitespaces)
                     )
                 }
-            )
+        )
     }
 
     public static func shouldAddSessionID(
@@ -471,7 +471,7 @@ public enum LogConfig {
             .Cheatsheet,
             .CookieCutter,
             .UI,
-            .OverflowMenu
+            .OverflowMenu,
         ]
 
         let validInteraction =

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -7,7 +7,7 @@ import Defaults
 import Foundation
 import Shared
 
-public struct LogConfig {
+public enum LogConfig {
     // MARK: - Interactions
     public enum Interaction: String {
         /// Open tracking shield
@@ -742,7 +742,7 @@ public struct LogConfig {
         }
     }
 
-    public struct Attribute {
+    public enum Attribute {
         /// Is selected tab in private mode
         public static let IsInPrivateMode = "IsInPrivateMode"
         /// Number of all tabs (normal + incognito) opened
@@ -795,14 +795,14 @@ public struct LogConfig {
         public static let InterstitialTimeSpent = "InterstitialTimeSpent"
     }
 
-    public struct UIInteractionAttribute {
+    public enum UIInteractionAttribute {
         /// View from which an UI Interaction is triggered
         public static let fromActionType = "fromActionType"
         public static let openSysSettingSourceView = "openSysSettingSourceView"
         public static let openSysSettingTriggerFrom = "openSysSettingTriggerFrom"
     }
 
-    public struct SuggestionAttribute {
+    public enum SuggestionAttribute {
         /// suggestion position
         public static let suggestionPosition = "suggestionPosition"
         /// number of characters typed in url bar
@@ -833,7 +833,7 @@ public struct LogConfig {
         public static let timeToSelectSuggestion = "TimeToSelectSuggestion"
     }
 
-    public struct SpacesAttribute {
+    public enum SpacesAttribute {
         public static let spaceID = "space_id"
         public static let spaceEntityID = "SpaceEntityID"
         public static let isShared = "isShared"
@@ -842,17 +842,17 @@ public struct LogConfig {
         public static let socialShareApp = "ShareAppName"
     }
 
-    public struct PromoCardAttribute {
+    public enum PromoCardAttribute {
         public static let promoCardType = "promoCardType"
         public static let defaultBrowserInterstitialTrigger = "defaultBrowserInterstitialTrigger"
     }
 
-    public struct ExperimentAttribute {
+    public enum ExperimentAttribute {
         public static let experiment = "Experiment"
         public static let experimentArm = "ExperimentArm"
     }
 
-    public struct CheatsheetAttribute {
+    public enum CheatsheetAttribute {
         public static let currentCheatsheetQuery = "currentCheatsheetQuery"
         public static let currentPageURL = "currentCheatsheetPageURL"
         public static let cheatsheetQuerySource = "cheatsheetQuerySource"
@@ -872,13 +872,13 @@ public struct LogConfig {
         }
     }
 
-    public struct TabsAttribute {
+    public enum TabsAttribute {
         public static let selectedTabSection = "SelectedTabSection"
         public static let selectedTabIndex = "SelectedTabIndex"
         public static let selectedTabRow = "SelectedTabRow"
     }
 
-    public struct NotificationAttribute {
+    public enum NotificationAttribute {
         public static let notificationPromptCallSite = "NotificationPromptCallSite"
         public static let notificationAuthorizationCallSite = "notificationAuthorizationCallSite"
 
@@ -888,7 +888,7 @@ public struct LogConfig {
         public static let notificationCampaignId = "NotificationCampaignId"
     }
 
-    public struct SpotlightAttribute {
+    public enum SpotlightAttribute {
         public static let urlPayload = "urlPayload"
         public static let spaceIdPayload = "spaceIdPayload"
         public static let addActivityToSpotlight = "addActivityToSpotlight"
@@ -919,26 +919,26 @@ public struct LogConfig {
         }
     }
 
-    public struct PerformanceAttribute {
+    public enum PerformanceAttribute {
         public static let memoryUsage = "MemoryUsage"
     }
 
-    public struct TabGroupAttribute {
+    public enum TabGroupAttribute {
         public static let numTabsInTabGroup = "NumTabsInTabGroup"
         public static let TabGroupRowIndex = "SelectedTabGroupRowIndex"
         public static let isExpanded = "IsExpanded"
         public static let selectedChildTabIndex = "SelectedChildTabIndex"
     }
 
-    public struct DeeplinkAttribute {
+    public enum DeeplinkAttribute {
         public static let searchRedirect = "SearchRedirect"
     }
 
-    public struct TrackingProtectionAttribute {
+    public enum TrackingProtectionAttribute {
         public static let toggleProtectionForURL = "ToggleProtectionForURL"
     }
 
-    public struct Web3Attribute {
+    public enum Web3Attribute {
         public static let walletAddress = "WalletAddress"
         public static let connectedSite = "ConnectedSite"
         public static let partnerCollection = "PartnerCollection"

--- a/Client/Logging/LogConfig.swift
+++ b/Client/Logging/LogConfig.swift
@@ -462,21 +462,22 @@ public enum LogConfig {
         for path: LogConfig.Interaction
     ) -> Bool {
         let category = LogConfig.category(for: path)
-        let validCategory =
-            category == .FirstRun
-            || category == .Stability
-            || category == .PromoCard
-            || category == .Web3
-            || category == .Notification
-            || category == .Cheatsheet
-            || category == .CookieCutter
-            || category == .UI
-            || category == .OverflowMenu
+        let validCategories: Set<LogConfig.InteractionCategory> = [
+            .FirstRun,
+            .Stability,
+            .PromoCard,
+            .Web3,
+            .Notification,
+            .Cheatsheet,
+            .CookieCutter,
+            .UI,
+            .OverflowMenu
+        ]
 
         let validInteraction =
             path == .SpacesLoginRequired || path == .SpacesRecommendedDetailUIVisited
 
-        return validCategory || validInteraction
+        return validCategories.contains(category) || validInteraction
     }
 
     // MARK: - Category


### PR DESCRIPTION
Changes:
- Replace `struct` with `enum`
- Use sets instead of chained booleans
- use sequence operators to parse logging categories

## Checklists

### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

### Manual test cases
Tested making logs

### Screenshots and screen recordings

## Issues addressed
