### PR TITLE
[Perf] Reduce SpaceCardsViewModel Creation

### DIFF
--- a/Client/Frontend/Browser/Card/CardListViews.swift
+++ b/Client/Frontend/Browser/Card/CardListViews.swift
@@ -13,8 +13,8 @@ class SpaceCardsViewModel: ObservableObject {
     init(spacesModel: SpaceCardModel) {
         subscriber = spacesModel.$allDetails
             .combineLatest(spacesModel.$filterState, spacesModel.$sortType, spacesModel.$sortOrder)
-            .sink { (arr, filter, sort, order) in
-                self.dataSource =
+            .sink { [weak self] (arr, filter, sort, order) in
+                self?.dataSource =
                     arr.filter {
                         NeevaFeatureFlags[.enableSpaceDigestCard]
                             || $0.id != SpaceStore.dailyDigestID

--- a/Client/Frontend/Browser/Card/CardListViews.swift
+++ b/Client/Frontend/Browser/Card/CardListViews.swift
@@ -30,7 +30,7 @@ struct SpaceCardsView: View {
     @ObservedObject var viewModel: SpaceCardsViewModel
 
     init(spacesModel: SpaceCardModel) {
-        self.viewModel = SpaceCardsViewModel(spacesModel: spacesModel)
+        self.viewModel = spacesModel.cardsViewModel
     }
 
     var body: some View {

--- a/Client/Frontend/Browser/Card/CardModels.swift
+++ b/Client/Frontend/Browser/Card/CardModels.swift
@@ -549,6 +549,8 @@ class SpaceCardModel: CardModel {
     @Published var sortType: SpaceSortState = .updatedDate
     @Published var sortOrder: SpaceSortOrder = .descending
 
+    private(set) var cardsViewModel: SpaceCardsViewModel!
+
     var thumbnailURLCandidates = [URL: [URL]]()
     private var anyCancellable: AnyCancellable? = nil
     private var recommendationSubscription: AnyCancellable? = nil
@@ -574,6 +576,8 @@ class SpaceCardModel: CardModel {
         }.store(in: &detailsSubscriptions)
         listenManagerState()
         listenSpaceMutations()
+
+        cardsViewModel = SpaceCardsViewModel(spacesModel: self)
     }
 
     private func listenManagerState() {

--- a/Client/Frontend/Browser/Card/CardModels.swift
+++ b/Client/Frontend/Browser/Card/CardModels.swift
@@ -597,6 +597,10 @@ class SpaceCardModel: CardModel {
                 if indexInStore != indexInDetails {
                     let indices: IndexSet = [indexInDetails]
                     self.allDetails.move(fromOffsets: indices, toOffset: indexInStore)
+                } else {
+                    // without moving the elements around, the array struct is unchanged
+                    // because the elements are reference types. We need to signal a refresh
+                    self.cardsViewModel.refresh()
                 }
                 return
             }


### PR DESCRIPTION
One perf issue identified:
- a new `SpaceCardsViewModel` is created each time `SpaceCardsView` is re-rendered
- each `SpaceCardsView` is persistent
- each `SpaceCardsView` has a sink on `SpaceCardModel.allDetails` where it sorts all spaces
- as a result, `sortSpaces` takes up lots of CPU and memory access

See screenshots for before and after profiling. This should improve performance when app is running in foreground where card grid is updated often. I don't think this well help with the case where app has 20 sec+ load time lol.

Changes:
- Make `SpaceCardModel`, which we seem to only have one instance of, create and own a single `SpaceCardsViewModel`. the `SpaceCardsView` will just access that property and use it as it's `ObservedObject`

## Checklists

### How was this tested?
- [x] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

### Manual test cases
Profiling flow
- Profile with CPU profiler and allocation list
- Launch app, wait til webpage finishes loading, mark generation
- Go to spaces in tab manager, mark generation
- Change a sort option (specifically, toggle ascending/descending for last updated), mark generation
- exit tab switcher, mark generation

### Screenshots and screen recordings
| Profiler Track | Before | After |
| ------- | ------- | ------- |
| CPU | <img width="1516" alt="Screen Shot 2022-07-12 at 11 47 09 AM" src="https://user-images.githubusercontent.com/44557675/178572169-9fda93d9-cd39-498c-870c-75b036d230dd.png"> | <img width="1513" alt="Screen Shot 2022-07-12 at 11 56 38 AM" src="https://user-images.githubusercontent.com/44557675/178572790-bf2ade68-2027-489e-ac5e-effab8020872.png"> |
| Allocation | <img width="1511" alt="Screen Shot 2022-07-12 at 11 47 00 AM" src="https://user-images.githubusercontent.com/44557675/178572213-2d1cab0e-ec8d-433a-923d-5108d0f47afc.png"> | <img width="1522" alt="Screen Shot 2022-07-12 at 11 56 53 AM" src="https://user-images.githubusercontent.com/44557675/178572834-4e25d1b7-71f7-40b3-ad6d-d0cf391e446f.png"> |

## Issues addressed
* Link(s) to Github issue(s) (if applicable)
