### PR TITLE
Fix #3998 by disabling the button and setting the foreground color to gray

### DIFF
--- a/Client/Frontend/Browser/Tabs/ArchivedTabs/ArchivedTabsPanelView.swift
+++ b/Client/Frontend/Browser/Tabs/ArchivedTabs/ArchivedTabsPanelView.swift
@@ -44,7 +44,7 @@ struct ArchivedTabsPanelView: View {
         HStack(spacing: 0) {
             Text("Clear All Archived Tabs")
                 .withFont(.bodyLarge)
-                .foregroundColor(.red)
+                .foregroundColor(model.numOfArchivedTabs < 1 ? .gray : .red)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.vertical, 10)
             Spacer()
@@ -124,6 +124,7 @@ struct ArchivedTabsPanelView: View {
                             }
                     }
                 }
+                    .disabled(model.numOfArchivedTabs < 1)
 
                 NavigationLink(isActive: $showArchivedTabsSettings) {
                     ArchivedTabSettings()

--- a/Client/Frontend/Browser/Tabs/ArchivedTabs/ArchivedTabsPanelView.swift
+++ b/Client/Frontend/Browser/Tabs/ArchivedTabs/ArchivedTabsPanelView.swift
@@ -44,7 +44,7 @@ struct ArchivedTabsPanelView: View {
         HStack(spacing: 0) {
             Text("Clear All Archived Tabs")
                 .withFont(.bodyLarge)
-                .foregroundColor(model.numOfArchivedTabs < 1 ? .gray : .red)
+                .foregroundColor(model.numOfArchivedTabs < 1 ? .tertiaryLabel : .red)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.vertical, 10)
             Spacer()
@@ -124,7 +124,7 @@ struct ArchivedTabsPanelView: View {
                             }
                     }
                 }
-                    .disabled(model.numOfArchivedTabs < 1)
+                .disabled(model.numOfArchivedTabs < 1)
 
                 NavigationLink(isActive: $showArchivedTabsSettings) {
                     ArchivedTabSettings()


### PR DESCRIPTION
_General description of what your PR does, written in a way that someone six
months from now could understand what you were doing when tracking down a bug
or attempting to add new functionality_

* More details about the changes
* Even more details about the changes
* Yet more details about the changes

## Checklists

### How was this tested?
- [X ] I tested this manually
- [ ] I added automated tests
- [ ] Existing automated tests are enough to cover my changes

### Manual test cases
If manually tested, describe the different scenarios you followed to ensure
that your changes work.  Make sure that you've tested as many pathways as
possible -- not just the [happy path](https://en.wikipedia.org/wiki/Happy_path).
I tested this by changing the date to archive a tab and then seeing if the button worked, it did so I cleared the archive and then the button was disabled again.
### Screenshots and screen recordings
Images or videos showing the effect of your PR.  Examples include:
* For new Views, add images of `_Previews` you have added for both light
  and dark mode
* Before and after screenshots showing the effect of your styling changes
* Videos showing you performing the flow that you have changed

![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 06 51 53](https://user-images.githubusercontent.com/87457198/182471174-a76d46f2-a57f-4f9d-8b87-afeac98f92d0.png)
![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 06 52 02](https://user-images.githubusercontent.com/87457198/182471188-eb8dedd5-4457-4e74-aa1b-146723936512.png)

## Issues addressed
* Link(s) to Github issue(s) (if applicable)
* #3998 
