### PR TITLE
Change Where TopBar Vertical Padding is Added

### DIFF
--- a/Client/Frontend/Browser/BrowserTopBarView.swift
+++ b/Client/Frontend/Browser/BrowserTopBarView.swift
@@ -5,10 +5,10 @@
 import Defaults
 import SwiftUI
 
-private enum BrowserTopBarViewUX {
+enum BrowserTopBarViewUX {
     static let GridPickerBottomPadding: CGFloat = 4.5
     static let ShowHeaderTapAreaHeight = 32.0
-    static let SwitcherToolbarViewBottomPadding: CGFloat = 7.5
+    static let SwitcherToolbarViewPadding: CGFloat = 3.75
 }
 
 struct BrowserTopBarView: View {
@@ -24,10 +24,8 @@ struct BrowserTopBarView: View {
     @ViewBuilder var switcherTopBar: some View {
         if chromeModel.inlineToolbar {
             SwitcherToolbarView(top: true)
-                .padding(.bottom, BrowserTopBarViewUX.SwitcherToolbarViewBottomPadding)
         } else {
             GridPicker()
-                .padding(.bottom, BrowserTopBarViewUX.GridPickerBottomPadding)
         }
     }
 

--- a/Client/Frontend/Browser/CardGrid/Grid/GridPicker.swift
+++ b/Client/Frontend/Browser/CardGrid/Grid/GridPicker.swift
@@ -80,6 +80,9 @@ struct GridPicker: View {
     var body: some View {
         picker
             .frame(height: gridModel.pickerHeight)
+            .if(!isInToolbar) {
+                $0.padding(.bottom, BrowserTopBarViewUX.GridPickerBottomPadding)
+            }
             .background(
                 (!isInToolbar
                     ? Color.DefaultBackground : Color.clear)

--- a/Client/Frontend/Browser/CardGrid/Grid/SwitcherToolbarView.swift
+++ b/Client/Frontend/Browser/CardGrid/Grid/SwitcherToolbarView.swift
@@ -192,8 +192,9 @@ struct SwitcherToolbarView: View {
                 .allowsHitTesting(toolbarModel.tabIsSelected)
             }
             .padding(.horizontal, 16)
-            .frame(
-                height: top ? UIConstants.TopToolbarHeightWithToolbarButtonsShowing - 1 : nil)
+            .if(top) {
+                $0.padding(.vertical, BrowserTopBarViewUX.SwitcherToolbarViewPadding)
+            }
 
             if top {
                 divider


### PR DESCRIPTION
Caused by #4375 adding the padding in the wrong location.

### Screenshots and screen recordings

![Simulator Screen Shot - iPhone 14 Pro - 2022-09-22 at 14 17 38](https://user-images.githubusercontent.com/37356984/191853109-dfda9423-da33-47ca-bf3a-187bdbd0f612.png)

<img src=https://user-images.githubusercontent.com/37356984/191853203-37b69974-e1a8-4399-b15c-0cfc49766c6c.png width=300>

https://user-images.githubusercontent.com/37356984/191853099-d5bed685-bd8c-45a2-b07b-2da583fdaeff.mp4

## Issues addressed
Fixed: #4403 
