### PR TITLE
premium; monthly product change

### DIFF
--- a/Client/Application/StoreKitLocalTesting.storekit
+++ b/Client/Application/StoreKitLocalTesting.storekit
@@ -66,12 +66,37 @@
           "referenceName" : "Annual (local)",
           "subscriptionGroupID" : "EFA616AA",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "5.99",
+          "familyShareable" : false,
+          "groupNumber" : 3,
+          "internalID" : "D6B1D26F",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Monthly Plan",
+              "displayName" : "Monthly (local)",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "monthly202209",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly (local)",
+          "subscriptionGroupID" : "EFA616AA",
+          "type" : "RecurringSubscription"
         }
       ]
     }
   ],
   "version" : {
-    "major" : 1,
-    "minor" : 2
+    "major" : 2,
+    "minor" : 0
   }
 }


### PR DESCRIPTION
This PR introduces a new monthly product while allowing the previous one to be deprecated.
- [ ] If we take the approach of adding a new product id, this PR needs to better handle the settings screen; a user should be able to see their current subscription product (which could be deprecated) and not the currently offered one.

NOTE: I found that we can change the price of the monthly subscription while preserving the price for existing subscribers. I'm hoping we take this route instead of introducing a new product id.

## Checklists

### How was this tested?
- [x] I tested this manually

### Manual test cases
TBD

### Screenshots and screen recordings
N/A

## Issues addressed
N/A
