### PR TITLE
settings; premium availability check update

### DIFF
--- a/Client/Frontend/Settings/Neeva/NeevaAccountInfoView.swift
+++ b/Client/Frontend/Settings/Neeva/NeevaAccountInfoView.swift
@@ -48,7 +48,8 @@ struct NeevaAccountInfoView: View {
                 // Only show for iOS 15 users who are in a country where Premium is offered
                 // and are not Lifetime and have not paid through another source.
                 if PremiumStore.isOfferedInLanguage() && userInfo.subscriptionType != .lifetime
-                    && (userInfo.subscription?.source == SubscriptionSource.none
+                    && (userInfo.subscription == nil
+                        || userInfo.subscription?.source == SubscriptionSource.none
                         || userInfo.subscription?.source == SubscriptionSource.apple)
                 {
                     NavigationLink(


### PR DESCRIPTION
We had a report from a user where they saw the premium screen and then upgraded to iOS 16 and when they went back the menu item for premium was gone. I'm not sure if this will help resolve that, but it may be worth a try.

## Checklists

### How was this tested?
- [x] I tested this manually

### Manual test cases
Simulator.

### Screenshots and screen recordings
N/A

## Issues addressed
N/A