### PR TITLE
Unpin tab when pin badge is clicked

### DIFF
--- a/Client/Frontend/Browser/CardGrid/Card/CardDetails.swift
+++ b/Client/Frontend/Browser/CardGrid/Card/CardDetails.swift
@@ -243,9 +243,15 @@ public class TabCardDetails: CardDropDelegate, CardDetails, AccessingManagerProv
         super.dropEntered(info: info)
     }
 
+    // TODO: Give this function a clearer name
+    // The button closes AND unpins the tab, depending on its state.
     func onClose() {
         if !tab.isPinned {
             manager.close(tab)
+        } else {
+            manager.toggleTabPinnedState(tab)
+            ToastDefaults().showToastForPinningTab(
+                pinning: false, tabManager: manager)
         }
     }
 


### PR DESCRIPTION
This resolves an odd UX quirk where the pin badge on a tab card did nothing. Now it will unpin the tab.

## Checklists

### How was this tested?
- [x] I tested this manually

### Screenshots and screen recordings
https://user-images.githubusercontent.com/41495718/206808100-3dc2e301-12b2-4f5a-838d-b22ccac3593e.mp4

## Issues addressed
* 🔒 https://app.clickup.com/t/3w3ayyp
